### PR TITLE
Fix-up stop

### DIFF
--- a/pkg/hypervctl/error.go
+++ b/pkg/hypervctl/error.go
@@ -3,7 +3,10 @@
 
 package hypervctl
 
-import "errors"
+import (
+	"errors"
+	"fmt"
+)
 
 // VM State errors
 var (
@@ -44,4 +47,71 @@ func (e DestroySystemResult) Reason() string {
 		return "invalid state"
 	}
 	return "Unknown"
+}
+
+// Shutdown operation error codes
+const (
+	ErrShutdownFailed           = 32768
+	ErrShutdownAccessDenied     = 32769
+	ErrShutdownNotSupported     = 32770
+	ErrShutdownStatusUnkown     = 32771
+	ErrShutdownTimeout          = 32772
+	ErrShutdownInvalidParameter = 32773
+	ErrShutdownSystemInUse      = 32774
+	ErrShutdownInvalidState     = 32775
+	ErrShutdownIncorrectData    = 32776
+	ErrShutdownNotAvailable     = 32777
+	ErrShutdownOutOfMemory      = 32778
+	ErrShutdownFileNotFound     = 32779
+	ErrShutdownNotReady         = 32780
+	ErrShutdownMachineLocked    = 32781
+	ErrShutdownInProgress       = 32782
+)
+
+
+type shutdownCompError struct {
+	errorCode int
+	message   string
+}
+
+func (s *shutdownCompError) Error() string {
+	return fmt.Sprintf("%s (%d)", s.message, s.errorCode)
+}
+
+func translateShutdownError(code int) error {
+	var message string
+	switch code {
+	case ErrShutdownFailed:
+		message = "shutdown failed"
+	case ErrShutdownAccessDenied:
+		message = "access was denied"
+	case ErrShutdownNotSupported:
+		message = "shutdown not supported by virtual machine"
+	case ErrShutdownStatusUnkown:
+		message = "virtual machine status is unknown"
+	case ErrShutdownTimeout:
+		message = "timeout starting shutdown"
+	case ErrShutdownInvalidParameter:
+		message = "invalid parameter"
+	case ErrShutdownSystemInUse:
+		message = "system in use"
+	case ErrShutdownInvalidState:
+		message = "virtual machine is in an invalid state for shutdown"
+	case ErrShutdownIncorrectData:
+		message = "incorrect data type"
+	case ErrShutdownNotAvailable:
+		message = "system is not available"
+	case ErrShutdownOutOfMemory:
+		message = "out of memory"
+	case ErrShutdownFileNotFound:
+		message = "file not found"
+	case ErrShutdownMachineLocked:
+		message = "machine is locked and cannot be shut down without the force option"
+	case ErrShutdownInProgress:
+		message = "shutdown is already in progress"
+	default:
+		message = "unknown error"
+	}
+
+	return &shutdownCompError{code, message}
 }

--- a/pkg/hypervctl/vm.go
+++ b/pkg/hypervctl/vm.go
@@ -15,6 +15,7 @@ import (
 	"github.com/containers/libhvee/pkg/wmiext"
 )
 
+
 // delete this when close to being done
 var (
 	ErrNotImplemented = errors.New("function not implemented")
@@ -206,7 +207,6 @@ func (vm *VirtualMachine) Stop() error {
 	}
 	var (
 		err error
-		job *wmiext.Instance
 		res int32
 		srv *wmiext.Service
 	)
@@ -222,12 +222,16 @@ func (vm *VirtualMachine) Stop() error {
 		In("Reason", "User requested").
 		In("Force", false).
 		Execute().
-		Out("Job", &job).
 		Out("ReturnValue", &res).End()
 	if err != nil {
 		return err
 	}
-	return waitVMResult(res, srv, job)
+
+	if res != 0 {
+		return translateShutdownError(int(res))
+	}
+
+	return nil
 }
 
 func (vm *VirtualMachine) Start() error {

--- a/pkg/wmiext/invoke.go
+++ b/pkg/wmiext/invoke.go
@@ -58,10 +58,10 @@ func (e *MethodExecutor) Out(name string, value interface{}) *MethodExecutor {
 		dest = dest.Elem()
 
 		variant, cimType, _, e.err = e.outParam.GetAsVariant(name)
-		defer variant.Clear()
 		if e.err != nil || variant == nil {
 			return e
 		}
+		defer variant.Clear()
 		if _, ok := value.(**Instance); ok && cimType == CIM_REFERENCE {
 			path := variant.ToString()
 			result, e.err = e.service.GetObject(path)


### PR DESCRIPTION
- Fixes NPE when out parameter doesn't exist
- Updates Stop() to use a job-less error handling (initiatie shutdown doesn't return a job, even though it has a status code that implies it)



