### PR TITLE
Add network bool for default hyperv network

### DIFF
--- a/pkg/hypervctl/vm.go
+++ b/pkg/hypervctl/vm.go
@@ -395,9 +395,6 @@ func (vmm *VirtualMachineManager) NewVirtualMachine(name string, config *Hardwar
 		return err
 	}
 
-	//if err := vmm.CreateVhdxFile(config.DiskPath, config.DiskSize*1024*1024*1024); err != nil {
-	//	return err
-	//}
 	if err := NewDriveSettingsBuilder(systemSettings).
 		AddScsiController().
 		AddSyntheticDiskDrive(0).
@@ -416,13 +413,15 @@ func (vmm *VirtualMachineManager) NewVirtualMachine(name string, config *Hardwar
 		return err
 	}
 	// Add default network connection
-	if err := NewNetworkSettingsBuilder(systemSettings).
-		AddSyntheticEthernetPort(nil).
-		AddEthernetPortAllocation(""). // "" = connect to default switch
-		Finish().                      // allocation
-		Finish().                      // port
-		Complete(); err != nil {
-		return err
+	if config.Network {
+		if err := NewNetworkSettingsBuilder(systemSettings).
+			AddSyntheticEthernetPort(nil).
+			AddEthernetPortAllocation(""). // "" = connect to default switch
+			Finish().                      // allocation
+			Finish().                      // port
+			Complete(); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/pkg/hypervctl/vm_config.go
+++ b/pkg/hypervctl/vm_config.go
@@ -98,6 +98,9 @@ type HardwareConfig struct {
 	DiskSize uint64
 	// Memory in megabytes assigned to the vm
 	Memory int32
+	// Network is bool to add a Network Connection to the
+	// default network switch in Microsoft HyperV
+	Network bool
 }
 
 type Statuses struct {


### PR DESCRIPTION
now that podman is able to use vsock networking, i added a network bool which determines if vm creation should have a default network that connects to the default network switch.