### PR TITLE
pkg/kvp: use `uint32` for `hvKvpMsgRet.error`, fixing 32-bit builds

### DIFF
--- a/pkg/kvp/config.go
+++ b/pkg/kvp/config.go
@@ -66,7 +66,10 @@ type hvKvpMsg struct {
 }
 
 type hvKvpMsgRet struct {
-	error  int
+	// on 64-bit Linux, C int is 32 bits but Go int is 64 bits.  use
+	// unsigned because error values are hex constants outside signed
+	// integer range.
+	error  uint32
 	kvpSet hvKvpMsgSet
 	// unused is needed to get to the same struct size as the C version.
 	unused [4856]byte


### PR DESCRIPTION
Error codes are represented as 32-bit hex constants with the high bit set, and these can't be assigned to a signed 32-bit field.  The error field is always 32 bits in the ABI, but we were making it 64 bits on 64-bit systems. Since we're on little-endian machines, this didn't change the outcome (except to make the struct too large, which is apparently tolerated by the kernel ABI), but it did cause a compilation failure on 32-bit builds.

Fix by changing the field to a `uint32`.

@baude, could we get a new release with this fix?