### PR TITLE
changed wql selector to find virtual machines over WMI

### DIFF
--- a/pkg/hypervctl/vmm.go
+++ b/pkg/hypervctl/vmm.go
@@ -24,7 +24,7 @@ func NewVirtualMachineManager() *VirtualMachineManager {
 }
 
 func (vmm *VirtualMachineManager) GetAll() ([]*VirtualMachine, error) {
-	const wql = "Select * From Msvm_ComputerSystem Where Caption = 'Virtual Machine'"
+	const wql = "Select * From Msvm_ComputerSystem Where Description = 'Microsoft Virtual Machine'"
 
 	var service *wmiext.Service
 	var err error
@@ -69,7 +69,7 @@ func (vmm *VirtualMachineManager) Exists(name string) (bool, error) {
 }
 
 func (*VirtualMachineManager) GetMachine(name string) (*VirtualMachine, error) {
-	const wql = "Select * From Msvm_ComputerSystem Where Caption = 'Virtual Machine' And ElementName='%s'"
+	const wql = "Select * From Msvm_ComputerSystem Where Description = 'Microsoft Virtual Machine' And ElementName='%s'"
 
 	vm := &VirtualMachine{}
 	var service *wmiext.Service


### PR DESCRIPTION
Changed from 'Caption' to 'Description' because the caption property gets localized in windows and no virtual machines are found because the selector does not match. The description property instead gets not localized and is always 'Microsoft Virtual Machine'.