### PR TITLE
Fix executable builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,23 +2,26 @@ export GOOS=windows
 export GOARCH=amd64
 SRC = $(shell find . -type f -name '*.go')
 
-GOLANGCI_LINT_VERSION := 1.54.2
-.PHONY: .install.golangci-lint
-.install.golangci-lint:
-	VERSION=$(GOLANGCI_LINT_VERSION) ./hack/install_golangci.sh
-
-.PHONY: validate
-validate:
-	./bin/golangci-lint run
-
 .PHONY: default
 default: build
 
+GOLANGCI_LINT_VERSION := 1.54.2
+bin/golangci-lint:
+	VERSION=$(GOLANGCI_LINT_VERSION) ./hack/install_golangci.sh
+
+.PHONY: .install.golangci-lint
+.install.golangci-lint: bin bin/golangci-lint
+
+.PHONY: validate
+validate: bin/golangci-lint
+	./bin/golangci-lint run
+
 .PHONY: build 
-build: bin bin/kvpctl.exe bin/dumpvms.exe bin/wmigen bin/createvm.exe bin/dumpsummary.exe bin/updatevm.exe
+build: validate bin bin/kvpctl.exe bin/dumpvms.exe bin/createvm.exe bin/updatevm.exe
 
 bin:
 	mkdir -p bin
+
 
 bin/kvpctl.exe: $(SRC) go.mod go.sum
 	go build -o bin ./cmd/kvpctl
@@ -31,14 +34,6 @@ bin/createvm.exe: $(SRC) go.mod go.sum
 
 bin/updatevm.exe: $(SRC) go.mod go.sum
 	go build -o bin ./cmd/updatevm
-
-bin/dumpsummary.exe: $(SRC) go.mod go.sum
-	go build -o bin ./cmd/dumpsummary
-
-bin/wmigen: export GOOS=
-bin/wmigen: export GOARCH=
-bin/wmigen: $(SRC) go.mod go.sum
-	go build -o bin ./cmd/wmigen
 
 clean:
 	rm -rf bin


### PR DESCRIPTION
- Readjusts the Makefile to be in sync after recent cleanup
- Restores the default build task to build after validate
- Install lint as part of make validate when necessary
 