### PR TITLE
Add vmm function GetMachineExists

### DIFF
--- a/pkg/wmiext/error.go
+++ b/pkg/wmiext/error.go
@@ -1,6 +1,7 @@
 package wmiext
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -156,6 +157,11 @@ const (
 
 var (
 	wmiModule syscall.Handle
+)
+
+// VM Lookup errors
+var (
+	ErrNoResults = errors.New("no results found")
 )
 
 func init() {

--- a/pkg/wmiext/service.go
+++ b/pkg/wmiext/service.go
@@ -299,7 +299,7 @@ func (s *Service) FindFirstInstance(wql string) (*Instance, error) {
 	}
 
 	if instance == nil {
-		return nil, errors.New("no results found")
+		return nil, ErrNoResults
 	}
 
 	return instance, nil


### PR DESCRIPTION
Add a method on vmm where we can check if a VM exists and if it does, get a pointer to the VirtualMachine and its settings.
    
Also added an error called ErrNoResults which is used to distinguish between a problem looking something up vs the lookup does not exist.
    
Signed-off-by: Brent Baude <bbaude@redhat.com>
