### PR TITLE
Refresh VM state before attempting to rm

### DIFF
--- a/pkg/hypervctl/vm.go
+++ b/pkg/hypervctl/vm.go
@@ -568,8 +568,12 @@ func (vm *VirtualMachine) remove() (int32, error) {
 		srv *wmiext.Service
 	)
 
+	refreshVM, err := vm.vmm.GetMachine(vm.ElementName)
+	if err != nil {
+		return 0, err
+	}
 	// Check for disabled/stopped state
-	if !Disabled.equal(vm.EnabledState) {
+	if !Disabled.equal(refreshVM.EnabledState) {
 		return -1, ErrMachineStateInvalid
 	}
 	if srv, err = NewLocalHyperVService(); err != nil {


### PR DESCRIPTION
when a vm was running and then forceably stopped, the vm state still appearing as running and would error when trying to remove.  a simple refresh of the vm status fixes this.