### PR TITLE
test: update images to f41

### DIFF
--- a/test/e2e/fedora_test.go
+++ b/test/e2e/fedora_test.go
@@ -6,17 +6,18 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	. "github.com/onsi/ginkgo/v2"
 	"io"
 	"log"
 	"os"
 	"path/filepath"
 	"runtime"
+
+	. "github.com/onsi/ginkgo/v2"
 	"github.com/ulikunitz/xz"
 )
 
 const (
-	fedoraBaseDirEndpoint = "https://kojipkgs.fedoraproject.org/compose/cloud/latest-Fedora-Cloud-40/compose"
+	fedoraBaseDirEndpoint = "https://kojipkgs.fedoraproject.org/compose/cloud/latest-Fedora-Cloud-41/compose"
 )
 
 // Fedora metadata for cloud downloads

--- a/test/e2e/libhvee_test.go
+++ b/test/e2e/libhvee_test.go
@@ -31,6 +31,9 @@ func get(endpoint string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+	if resp.StatusCode != http.StatusOK {
+		Fail(fmt.Sprintf("get %s: status code: %d", endpoint, resp.StatusCode))
+	}
 	defer resp.Body.Close()
 	body, err := io.ReadAll(resp.Body)
 	return body, err
@@ -45,6 +48,9 @@ func pullWithProgress(endpoint string, dst *os.File) error {
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		Fail(err.Error())
+	}
+	if resp.StatusCode != http.StatusOK {
+		Fail(fmt.Sprintf("get %s: status code: %d", endpoint, resp.StatusCode))
 	}
 	defer resp.Body.Close()
 	return doWithProgress("downloading", resp.Body, dst, resp.ContentLength)


### PR DESCRIPTION
https://pagure.io/releng/issue/12521 was fixed so we can update to f41

Also fix some error checks on downloads. We got a 404 from the server so this is not something we should try to process.