### PR TITLE
attach DVD Drive on new VM

### DIFF
--- a/pkg/hypervctl/vm.go
+++ b/pkg/hypervctl/vm.go
@@ -430,7 +430,7 @@ func (vmm *VirtualMachineManager) NewVirtualMachine(name string, config *Hardwar
 		return err
 	}
 
-	if err := NewDriveSettingsBuilder(systemSettings).
+	builder := NewDriveSettingsBuilder(systemSettings).
 		AddScsiController().
 		AddSyntheticDiskDrive(0).
 		DefineVirtualHardDisk(config.DiskPath, func(vhdss *VirtualHardDiskStorageSettings) {
@@ -438,15 +438,24 @@ func (vmm *VirtualMachineManager) NewVirtualMachine(name string, config *Hardwar
 			// vhdss.IOPSLimit = 5000
 		}).
 		Finish(). // disk
-		Finish(). // drive
-		//AddSyntheticDvdDrive(1).
-		//DefineVirtualDvdDisk(isoFile).
-		//Finish(). // disk
-		//Finish(). // drive
+		Finish()  // drive
+
+	if config.DVDDiskPath != "" {
+		// Add a DVD drive if the DVDDiskPath is set
+		// This is useful for cloud-init or other bootable media
+		builder = builder.
+			AddSyntheticDvdDrive(1).
+			DefineVirtualDvdDisk(config.DVDDiskPath).
+			Finish(). // disk
+			Finish()  // drive
+	}
+
+	if err := builder.
 		Finish(). // controller
 		Complete(); err != nil {
 		return err
 	}
+
 	// Add default network connection
 	if config.Network {
 		if err := NewNetworkSettingsBuilder(systemSettings).

--- a/pkg/hypervctl/vm_config.go
+++ b/pkg/hypervctl/vm_config.go
@@ -101,6 +101,9 @@ type HardwareConfig struct {
 	// Network is bool to add a Network Connection to the
 	// default network switch in Microsoft HyperV
 	Network bool
+	// DVDDiskPath is the path to the disk image
+	// that will be used as a DVD drive in the VM (e.g. for cloud-init)
+	DVDDiskPath string
 }
 
 type Statuses struct {


### PR DESCRIPTION
this patch allows to attach a DVD device when creating a VM.

This is helpful when wanting to customize VM using cloud-init. By attaching the cloud-init config ISO as a DVD, we can deliver the configuration to the VM