### PR TITLE
lint fixes for golangci-lint v2.2

### DIFF
--- a/cmd/dumpvms/main.go
+++ b/cmd/dumpvms/main.go
@@ -20,7 +20,7 @@ func getVms() (string, error) {
 	vmms := hypervctl.VirtualMachineManager{}
 	vms, err := vmms.GetAll()
 	if err != nil {
-		return "", fmt.Errorf("Could not retrieve virtual machines: %s\n", err.Error())
+		return "", fmt.Errorf("Could not retrieve virtual machines: %s\n", err.Error()) // nolint:staticcheck
 	}
 	b, err := json.MarshalIndent(vms, "", "\t")
 	if err != nil {
@@ -33,7 +33,7 @@ func dumpSummary() (string, error) {
 	vmms := hypervctl.VirtualMachineManager{}
 	summs, err := vmms.GetSummaryInformation(hypervctl.SummaryRequestNearAll)
 	if err != nil {
-		return "", fmt.Errorf("Could not retrieve virtual machine summaries: %v\n", err)
+		return "", fmt.Errorf("Could not retrieve virtual machine summaries: %v\n", err) // nolint:staticcheck
 	}
 	b, err := json.MarshalIndent(summs, "", "\t")
 	if err != nil {

--- a/pkg/hypervctl/vm.go
+++ b/pkg/hypervctl/vm.go
@@ -218,7 +218,7 @@ func waitVMResult(res int32, service *wmiext.Service, job *wmiext.Instance, erro
 
 	if err != nil {
 		desc, _ := job.GetAsString("ErrorDescription")
-		desc = strings.Replace(desc, "\n", " ", -1)
+		desc = strings.ReplaceAll(desc, "\n", " ")
 		return fmt.Errorf("%s: %w (%s)", errorMsg, err, desc)
 	}
 

--- a/pkg/wmiext/array.go
+++ b/pkg/wmiext/array.go
@@ -41,7 +41,7 @@ func safeArrayCreateVector(variantType ole.VT, lowerBound int32, length uint32) 
 	if ret == 0 { // NULL return value
 		err = fmt.Errorf("could not create safe array")
 	}
-	safearray = (*ole.SafeArray)(unsafe.Pointer(ret))
+	safearray = (*ole.SafeArray)(unsafe.Pointer(ret)) //nolint:govet
 	return
 }
 
@@ -148,7 +148,10 @@ func safeArrayGetElement(safearray *ole.SafeArray, index int64, element unsafe.P
 }
 
 func isVariantValConvertible(variant ole.VARIANT) bool {
-	return !(variant.VT == ole.VT_RECORD || variant.VT == ole.VT_VARIANT)
+	if variant.VT == ole.VT_RECORD || variant.VT == ole.VT_VARIANT {
+		return false
+	}
+	return true
 }
 
 func safeArrayGetAsVariantVal(safeArray *ole.SafeArray, index int64, variant ole.VARIANT) (int64, error) {

--- a/pkg/wmiext/conversion.go
+++ b/pkg/wmiext/conversion.go
@@ -347,14 +347,14 @@ func convertTimeToDataTime(time *time.Time) ole.VARIANT {
 }
 
 func convertDurationToDateTime(duration time.Duration) ole.VARIANT {
-	const daySeconds = time.Second * 86400
+	const dayTime = time.Second * 86400
 
 	if duration == 0 {
 		return ole.NewVariant(ole.VT_NULL, 0)
 	}
 
-	days := duration / daySeconds
-	duration = duration % daySeconds
+	days := duration / dayTime
+	duration = duration % dayTime
 
 	hours := duration / time.Hour
 	duration = duration % time.Hour
@@ -435,7 +435,7 @@ func parseIntervalTime(interval string) (time.Time, error) {
 		return time.Time{}, err
 	}
 
-	var stamp uint64 = secs
+	var stamp = secs
 	stamp += days * 86400
 	stamp += hours * 3600
 	stamp += mins * 60

--- a/test/e2e/fedora_test.go
+++ b/test/e2e/fedora_test.go
@@ -91,7 +91,7 @@ type FedoraCloudPayload struct {
 }
 
 type fedoraCloudMetadata struct {
-	Header  fedoraCloudHeader  `json:"'header'"`
+	Header  fedoraCloudHeader  `json:"header"`
 	Payload FedoraCloudPayload `json:"payload"`
 }
 
@@ -117,8 +117,9 @@ func checkIfCacheExistsAndLatest(dst string, latestSha string) (bool, error) {
 		if err != nil {
 			log.Fatal(err)
 		}
-		defer f.Close()
-
+		defer func() {
+			_ = f.Close()
+		}()
 		h := sha256.New()
 		_, err = io.Copy(h, f)
 		if err != nil {
@@ -163,7 +164,9 @@ func getTestImage() (string, error) {
 		if err != nil {
 			return "", err
 		}
-		defer dst.Close()
+		defer func() {
+			_ = dst.Close()
+		}()
 		if err := pullWithProgress(downloadPath, dst); err != nil {
 			return "", err
 		}
@@ -182,8 +185,9 @@ func decompressVhdXZ(src string, dst string) error {
 	if err != nil {
 		return err
 	}
-	defer f.Close()
-
+	defer func() {
+		_ = f.Close()
+	}()
 	r, err := xz.NewReader(f)
 	if err != nil {
 		return fmt.Errorf("xz decompression failed: %v", err)
@@ -194,7 +198,9 @@ func decompressVhdXZ(src string, dst string) error {
 	if err != nil {
 		return err
 	}
-	defer outFile.Close()
+	defer func() {
+		_ = outFile.Close()
+	}()
 
 	_, err = io.Copy(outFile, r)
 	if err != nil {

--- a/test/e2e/libhvee_test.go
+++ b/test/e2e/libhvee_test.go
@@ -34,7 +34,9 @@ func get(endpoint string) ([]byte, error) {
 	if resp.StatusCode != http.StatusOK {
 		Fail(fmt.Sprintf("get %s: status code: %d", endpoint, resp.StatusCode))
 	}
-	defer resp.Body.Close()
+	defer func() {
+		_ = resp.Body.Close()
+	}()
 	body, err := io.ReadAll(resp.Body)
 	return body, err
 }
@@ -52,7 +54,9 @@ func pullWithProgress(endpoint string, dst *os.File) error {
 	if resp.StatusCode != http.StatusOK {
 		Fail(fmt.Sprintf("get %s: status code: %d", endpoint, resp.StatusCode))
 	}
-	defer resp.Body.Close()
+	defer func() {
+		_ = resp.Body.Close()
+	}()
 	return doWithProgress("downloading", resp.Body, dst, resp.ContentLength)
 }
 
@@ -65,7 +69,9 @@ func copyWithProgress(srcPath string, dst *os.File) error {
 	if err != nil {
 		return err
 	}
-	defer f.Close()
+	defer func() {
+		_ = f.Close()
+	}()
 	return doWithProgress("copying", f, dst, s.Size())
 }
 

--- a/test/e2e/vm_test.go
+++ b/test/e2e/vm_test.go
@@ -58,11 +58,6 @@ var defaultConfig = hypervctl.HardwareConfig{
 	Network:  false,
 }
 
-func newVMFromConfig(name string, config *hypervctl.HardwareConfig) (*hypervctl.VirtualMachineManager, *hypervctl.VirtualMachine, error) {
-	return newVM(name, config)
-
-}
-
 func (t *testVM) copyCacheDiskToVm() error {
 	if len(t.name) < 1 {
 		return errors.New("testVM has no name")
@@ -75,7 +70,9 @@ func (t *testVM) copyCacheDiskToVm() error {
 	if err != nil {
 		return err
 	}
-	defer dst.Close()
+	defer func() {
+		_ = dst.Close()
+	}()
 	return copyWithProgress(cachedImagePath, dst)
 }
 


### PR DESCRIPTION
it looks like newer version of golangci-lint is tripping over some new things it found.  this pr addresses those so CI can run green again.